### PR TITLE
Wjing build with make

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,6 @@ RUN apk update && apk add --no-cache \
     git \
     cmake \
     go \
-    ninja \
     linux-headers \
     file
 
@@ -39,8 +38,8 @@ RUN git clone --depth=1 --shallow-submodules --branch main https://boringssl.goo
   && cd boringssl \
   && mkdir build \
   && cd build \
-  && cmake -GNinja -DBUILD_SHARED_LIBS=1 .. \
-  && ninja
+  && cmake -DBUILD_SHARED_LIBS=1 .. \
+  && make
 
 # Prepare BoringSSL for Nginx compilation
 RUN mkdir -p "$BORINGSSL_LOCAL/boringssl/.openssl/lib" \

--- a/default.conf
+++ b/default.conf
@@ -1,9 +1,8 @@
 server {
     listen 80;
-    listen 443 ssl;
-    http2 on;
+    listen 443 ssl http2;
     listen 443 quic reuseport;
-    server_name localhost;
+    server_name wjing.xyz www.wjing.xyz;
     root /usr/share/nginx/html;
     index index.html;
     
@@ -11,11 +10,18 @@ server {
     add_header Alt-Svc 'h3=":443"; ma=86400';
     
     # SSL certificates
-    ssl_certificate /etc/ssl/localhost.pem;
-    ssl_certificate_key /etc/ssl/private/localhost.key;
+    ssl_certificate /etc/nginx/certs/live/wjing.xyz/fullchain.pem;
+    ssl_certificate_key /etc/nginx/certs/live/wjing.xyz/privkey.pem;
     
     # SSL settings
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_prefer_server_ciphers on;
     ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+
+    # OCSP Stapling
+    ssl_stapling on;
+    ssl_stapling_verify on;
+    ssl_trusted_certificate /etc/nginx/certs/live/wjing.xyz/chain.pem;
+    resolver 8.8.8.8 8.8.4.4 valid=300s;
+    resolver_timeout 5s;
 }

--- a/setup-ssl.sh
+++ b/setup-ssl.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -e
+
+# Replace these with your domain and email
+DOMAIN="wjing.xyz"
+PRIMARY_DOMAIN="www.wjing.xyz"
+EMAIL="wjing@wjing.dev"
+
+CONTAINER_NAME="nginx-https-server"
+IMAGE_NAME="nginx-http3"
+
+# Create directory for certbot
+mkdir -p ./certs/certbot
+
+# Stop any running nginx container
+docker stop $CONTAINER_NAME || true
+docker rm $CONTAINER_NAME || true
+
+# Get SSL certificate using certbot
+docker run -it --rm \
+  -v "$(pwd)/certs:/etc/letsencrypt" \
+  -v "$(pwd)/certs/certbot:/var/lib/letsencrypt" \
+  -p 80:80 \
+  certbot/certbot certonly \
+  --standalone \
+  --preferred-challenges http \
+  --email $EMAIL \
+  --agree-tos \
+  --no-eff-email \
+  -d $DOMAIN \
+  -d $PRIMARY_DOMAIN
+
+# Create symbolic links for nginx
+mkdir -p ./certs/live/$DOMAIN
+ln -sf ../../archive/$DOMAIN/fullchain1.pem ./certs/live/$DOMAIN/fullchain.pem
+ln -sf ../../archive/$DOMAIN/privkey1.pem ./certs/live/$DOMAIN/privkey.pem
+ln -sf ../../archive/$DOMAIN/chain1.pem ./certs/live/$DOMAIN/chain.pem
+
+# Start nginx with the new certificates
+docker run -d --name $CONTAINER_NAME \
+  -p 80:80 \
+  -p 443:443 \
+  -p 443:443/udp \
+  -v $(pwd)/certs:/etc/nginx/certs:ro \
+  -v $(pwd)/default.conf:/etc/nginx/conf.d/default.conf:ro \
+  $IMAGE_NAME
+
+# Set up automatic renewal
+echo "0 0 1 * * docker run --rm -v $(pwd)/certs:/etc/letsencrypt -v $(pwd)/certs/certbot:/var/lib/letsencrypt certbot/certbot renew --quiet && docker restart $CONTAINER_NAME" | sudo tee -a /var/spool/cron/crontabs/root
+
+echo "SSL certificates have been obtained and nginx has been started!"
+echo "Automatic renewal has been set up to run monthly." 


### PR DESCRIPTION
- Remove Ninja build system dependency
- Replace Ninja build with standard make command
- Simplify BoringSSL compilation steps
---
- Create setup-ssl.sh script for obtaining Let's Encrypt certificates
- Update default.conf with domain-specific SSL configuration
- Configure OCSP stapling and resolver settings
- Replace localhost certificates with domain-specific certificates
- Add automatic certificate renewal via crontab